### PR TITLE
ci: Update rnp build (newer cmake).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ env:
   global:
     - LOCAL_BUILDS="$HOME/local-builds"
     - BOTAN_INSTALL="${LOCAL_BUILDS}/botan-install"
-    - CMOCKA_INSTALL="${LOCAL_BUILDS}/cmocka-install"
     - JSONC_INSTALL="${LOCAL_BUILDS}/jsonc-install"
     - RNP_INSTALL="${LOCAL_BUILDS}/rnp-install"
-    - LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSONC_INSTALL}/lib:${RNP_INSTALL}/lib"
+    - LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${JSONC_INSTALL}/lib:${RNP_INSTALL}/lib"
   matrix:
     - RNP_VERSION=master
     - RNP_VERSION=v0.12.0
@@ -27,7 +26,6 @@ cache:
   bundler: true
   directories:
     - "$BOTAN_INSTALL"
-    - "$CMOCKA_INSTALL"
     - "$JSONC_INSTALL"
     - "$RNP_INSTALL"
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,6 +4,12 @@ set -eux
 : "${CORES:=2}"
 : "${MAKE:=make}"
 
+pushd /
+sudo curl -L -o cmake.sh https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh
+sudo sh cmake.sh --skip-license
+CMAKE=/bin/cmake
+popd
+
 # botan
 botan_build=${LOCAL_BUILDS}/botan
 if [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.so" ] && \
@@ -48,7 +54,7 @@ if [ ! -e "${RNP_INSTALL}/lib/librnp.so" ] && \
   git clone https://github.com/rnpgp/rnp ${rnp_build}
   pushd "${rnp_build}"
   git checkout "$RNP_VERSION"
-  cmake \
+  ${CMAKE} \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DBUILD_SHARED_LIBS=yes \
     -DBUILD_TESTING=no \


### PR DESCRIPTION
Also drop cmocka stuff that we probably never needed since
building rnp tests was not enabled.

Fixes #56.