### PR TITLE
Update development dependencies

### DIFF
--- a/rnp.gemspec
+++ b/rnp.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.55.0'
+  spec.add_development_dependency 'rubocop', '~> 0.75.0'
   spec.add_development_dependency 'simplecov', '~> 0.14'
   spec.add_development_dependency 'yard', '~> 0.9.12'
 

--- a/rnp.gemspec
+++ b/rnp.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['yard.run'] = 'yard'
 
-  spec.add_development_dependency 'asciidoctor', '~> 1.5'
+  spec.add_development_dependency 'asciidoctor', '~> 2.0'
   spec.add_development_dependency 'bundler', '>= 1.14', '< 3'
   spec.add_development_dependency 'codecov', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/rnp.gemspec
+++ b/rnp.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'asciidoctor', '~> 2.0'
   spec.add_development_dependency 'bundler', '>= 1.14', '< 3'
   spec.add_development_dependency 'codecov', '~> 0.1'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 10', '< 14'
   spec.add_development_dependency 'redcarpet', '~> 3.4'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'rubocop', '~> 0.75.0'


### PR DESCRIPTION
– AsciiDoctor
– Rake
– Rubocop

Some of them were very old. Rationale in respective commits.