### PR TITLE
Use Input.from_path instead of Input.from_io

### DIFF
--- a/spec/encrypt/simple_encrypt_spec.rb
+++ b/spec/encrypt/simple_encrypt_spec.rb
@@ -71,7 +71,7 @@ describe Rnp.instance_method(:encrypt) do
       'password'
     end
     decryptedf = Tempfile.new('ruby-rnp', encoding: Encoding::BINARY)
-    rnp.decrypt(input: Rnp::Input.from_io(@encryptedf), output: Rnp::Output.to_path(decryptedf.path))
+    rnp.decrypt(input: Rnp::Input.from_path(@encryptedf.path), output: Rnp::Output.to_path(decryptedf.path))
     decryptedf.open
     expect(decryptedf.read).to eql @plaintext
   end
@@ -79,7 +79,7 @@ describe Rnp.instance_method(:encrypt) do
   context "without AEAD",
           skip: !LibRnp::HAVE_RNP_DUMP_PACKETS_TO_JSON do
     it "does not contain AEAD packets" do
-      packets = Rnp.parse(input: Rnp::Input.from_io(@encryptedf))
+      packets = Rnp.parse(input: Rnp::Input.from_path(@encryptedf.path))
       expect(
         packets.select { |pkt| pkt["header"]["tag"] == 20 }.any?,
       ).to be false
@@ -243,7 +243,7 @@ describe Rnp.instance_method(:encrypt_and_sign) do
     end
     decryptedf = Tempfile.new("ruby-rnp", encoding: Encoding::BINARY)
     rnp.decrypt(
-      input: Rnp::Input.from_io(@encryptedf),
+      input: Rnp::Input.from_path(@encryptedf.path),
       output: Rnp::Output.to_path(decryptedf.path),
     )
     decryptedf.open


### PR DESCRIPTION
Not sure whether it is correct way to fix the issues (or we should fix Input.from_io instead?).
Got some semi-random failures in rnp PR tests run, and it doesn't seem to be related to library code updates.

Changed in this way works locally 100% cases, could it be related to some ruby updates or whatever else?