### PR TITLE
Update rspec to not depend on default encrypting subkey selection.

### DIFF
--- a/spec/encrypt/encrypt_spec.rb
+++ b/spec/encrypt/encrypt_spec.rb
@@ -135,8 +135,8 @@ describe Rnp::Encrypt do
                     input: Rnp::Input.from_path('spec/data/keyrings/gpg/secring.gpg'))
       rnp.password_provider = lambda do |key, _reason|
         return nil unless key
-        # this is the encrypting subkey for user2
-        expect(key.keyid).to eql '54505A936A4A970E'
+        # this is one of the encrypting subkeys for user2
+        expect(["54505A936A4A970E", "326EF111425D14A5"]).to include(key.keyid)
         return 'password'
       end
       expect(rnp.decrypt(input: Rnp::Input.from_string(@encrypted))).to eql plaintext

--- a/spec/encrypt/simple_encrypt_spec.rb
+++ b/spec/encrypt/simple_encrypt_spec.rb
@@ -40,7 +40,7 @@ describe Rnp.instance_method(:encrypt) do
     rnp = Rnp.new
     rnp.key_provider = lambda do |idtype, id, secret|
       expect(idtype).to eql 'keyid'
-      expect(id).to eql '1ED63EE56FADC34D'
+      expect(["1ED63EE56FADC34D", "8A05B89FAD5ADED1"]).to include(id)
       expect(secret).to eql true
       rnp.load_keys(format: 'GPG',
                     input: Rnp::Input.from_path('spec/data/keyrings/gpg/secring.gpg'))
@@ -66,7 +66,7 @@ describe Rnp.instance_method(:encrypt) do
     rnp.load_keys(format: 'GPG',
                   input: Rnp::Input.from_path('spec/data/keyrings/gpg/secring.gpg'))
     rnp.password_provider = lambda do |key, reason|
-      expect(key.keyid).to eql '1ED63EE56FADC34D'
+      expect(["1ED63EE56FADC34D", "8A05B89FAD5ADED1"]).to include(key.keyid)
       expect(reason).to eql 'decrypt'
       'password'
     end
@@ -199,7 +199,7 @@ describe Rnp.instance_method(:encrypt_and_sign) do
     rnp = Rnp.new
     rnp.key_provider = lambda do |idtype, id, secret|
       expect(idtype).to eql "keyid"
-      expect(id).to eql "1ED63EE56FADC34D"
+      expect(["1ED63EE56FADC34D", "8A05B89FAD5ADED1"]).to include(id)
       expect(secret).to eql true
       rnp.load_keys(
         format: "GPG",
@@ -237,7 +237,7 @@ describe Rnp.instance_method(:encrypt_and_sign) do
       input: Rnp::Input.from_path("spec/data/keyrings/gpg/secring.gpg"),
     )
     rnp.password_provider = lambda do |key, reason|
-      expect(key.keyid).to eql "1ED63EE56FADC34D"
+      expect(["1ED63EE56FADC34D", "8A05B89FAD5ADED1"]).to include(key.keyid)
       expect(reason).to eql "decrypt"
       "password"
     end


### PR DESCRIPTION
As https://github.com/rnpgp/rnp/pull/1318 changes behavior to use the latest encrypting subkey by default we should also update rspec to allow that case.
Since the default behavior may be changed again (say, to use the most strong subkey or so on), would allow both of the subkeys.