### PR TITLE
Update tests according to more relaxed userid validation rules.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         ruby: [2.5, 2.6, 2.7]
-        botan: [2.12.1, 2.17.2]
-        rnp: [master, v0.13.0]
+        botan: [2.14.0, 2.17.2]
+        rnp: [master, v0.15.1]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:

--- a/lib/rnp/misc.rb
+++ b/lib/rnp/misc.rb
@@ -276,6 +276,10 @@ class Rnp
     # Now userid is not considered as primary if it is revoked/expired/etc.
     "primary-userid-must-be-valid" => Rnp.version >= Rnp.version("0.14.0") ||
       Rnp.commit_time >= 1605875599,
+    # Behavior was changed in v0.15.2 (issue #1509):
+    # userid is valid even if key expiration in userid expiration expires key.
+    "relax-userid-validity-checks" => Rnp.version >= Rnp.version("0.15.2") ||
+      Rnp.commit_time >= 1624526708,
   }.freeze
 
   def self.has?(feature)

--- a/spec/key/properties/4BE147BB22DF1E60_spec.rb
+++ b/spec/key/properties/4BE147BB22DF1E60_spec.rb
@@ -47,7 +47,9 @@ describe Rnp::Key do
     end
 
     it 'raises an error when requesting primary userid' do
-      if Rnp.has?("primary-userid-must-be-valid")
+      if Rnp.has?("relax-userid-validity-checks")
+        expect(key.primary_userid).to eql "test1"
+      elsif Rnp.has?("primary-userid-must-be-valid")
         expect { key.primary_userid }.to raise_error(Rnp::Error)
       else
         expect(key.primary_userid).to eql "test1"


### PR DESCRIPTION
Related RNP PR : https://github.com/rnpgp/rnp/pull/1531