### PR TITLE
Update timeout for the signature checks in sign_spec.rb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rnp: [ v0.15.1 ]
+        rnp: [ v0.15.2 ]
     steps:
     - uses: actions/checkout@v1
 
@@ -24,7 +24,7 @@ jobs:
     - run: bundle exec rake gem:native
     - run: bundle exec rake gem
 
-    - uses: metanorma/metanorma-build-scripts/native-deps-action@master
+    - uses: metanorma/metanorma-build-scripts/native-deps-action@main
       with:
         libname: librnp
         directory: lib/rnp/ffi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rnp: [master, v0.15.1]
+        rnp: [master, v0.15.2]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
       env:
         RNP_VERSION: ${{ matrix.rnp }}
 
-    - uses: metanorma/metanorma-build-scripts/native-deps-action@master
+    - uses: metanorma/metanorma-build-scripts/native-deps-action@main
       with:
         libname: librnp
         directory: lib/rnp/ffi
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rnp: [master, v0.15.1]
+        rnp: [master, v0.15.2]
         ruby: [2.5, 2.6, 2.7, 3.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -59,4 +59,4 @@ jobs:
         bundler-cache: true
 
     - run: bundle exec rake
-      continue-on-error: ${{ matrix.rnp == 'v0.15.1' }}
+      continue-on-error: ${{ matrix.rnp == 'v0.15.2' }}

--- a/spec/sign/sign_spec.rb
+++ b/spec/sign/sign_spec.rb
@@ -70,7 +70,7 @@ describe Rnp::Verify do
 
     expect(sigs[0].hash).to eql 'SHA512'
     expect(sigs[0].key.keyid).to eql '7BC6709B15C23A4A'
-    expect(Time.now - sigs[0].creation_time).to be <= 5
+    expect(Time.now - sigs[0].creation_time).to be <= 10
     expect(sigs[0].expiration_time).to eql 60
     expect(sigs[0].good?).to be true
     expect(sigs[0].valid?).to be true
@@ -84,7 +84,7 @@ describe Rnp::Verify do
       expect(sigs[1].expiration_time).to eql 60
     end
     expect(sigs[1].key.keyid).to eql '2FCADF05FFA501BB'
-    expect(Time.now - sigs[0].creation_time).to be <= 5
+    expect(Time.now - sigs[0].creation_time).to be <= 10
     expect(sigs[1].good?).to be true
     expect(sigs[1].valid?).to be true
     expect(sigs[1].expired?).to be false


### PR DESCRIPTION
Latest changes in RNP (see https://github.com/rnpgp/rnp/pull/1737) introduce key secret material checks before the first operation. This increases time needed to do sign/verify steps, failing corresponding ruby-rnp test.