### PR TITLE
Update tests to support new 2-year default key expiry.

### DIFF
--- a/lib/rnp/misc.rb
+++ b/lib/rnp/misc.rb
@@ -280,6 +280,10 @@ class Rnp
     # userid is valid even if key expiration in userid expiration expires key.
     "relax-userid-validity-checks" => Rnp.version >= Rnp.version("0.15.2") ||
       Rnp.commit_time >= 1624526708,
+    # Behavior on default key expiration time was changed:
+    # Now default key expiration time is 2 years
+    "default-key-expiration-2-years" => Rnp.version >= Rnp.version("0.17.0") ||
+      Rnp.commit_time >= 1645578982,
   }.freeze
 
   def self.has?(feature)

--- a/spec/generate/generate_spec.rb
+++ b/spec/generate/generate_spec.rb
@@ -336,7 +336,11 @@ describe Rnp.instance_method(:start_generate_subkey),
     end
 
     it "has the correct validity period" do
-      expect(@json["expiration"]).to be 0
+      if Rnp.has?("default-key-expiration-2-years")
+        expect(@json["expiration"]).to be 63072000
+      else
+        expect(@json["expiration"]).to be 0
+      end
     end
   end
 end


### PR DESCRIPTION
...changed via the PR https://github.com/rnpgp/rnp/pull/1773