### PR TITLE
Fix CI on RNP branches based on 0.16.0

### DIFF
--- a/lib/rnp/misc.rb
+++ b/lib/rnp/misc.rb
@@ -282,8 +282,7 @@ class Rnp
       Rnp.commit_time >= 1624526708,
     # Behavior on default key expiration time was changed:
     # Now default key expiration time is 2 years
-    "default-key-expiration-2-years" => Rnp.version >= Rnp.version("0.17.0") ||
-      Rnp.commit_time >= 1645578982,
+    "default-key-expiration-2-years" => Rnp.version >= Rnp.version("0.17.0"),
   }.freeze
 
   def self.has?(feature)

--- a/spec/generate/generate_spec.rb
+++ b/spec/generate/generate_spec.rb
@@ -337,9 +337,9 @@ describe Rnp.instance_method(:start_generate_subkey),
 
     it "has the correct validity period" do
       if Rnp.has?("default-key-expiration-2-years")
-        expect(@json["expiration"]).to be 63072000
+        expect(@json["expiration"]).to eq 63072000
       else
-        expect(@json["expiration"]).to be 0
+        expect(@json["expiration"]).to eq 0
       end
     end
   end


### PR DESCRIPTION
The way the test suite distinguishes between RNP 0.16.x releases and master branch (and future releases) is unfortunate as it looks at the last commit date. So fresh commits which are intended to become 0.16.1 make it treated the same as master, although the new feature (present only on master so far) is not being backported.

This change should be landed in coordination with another change for the RNP repo, changing version.txt from `0.16.0` to `0.17.0` or something which would cause the distinction to work as intended.